### PR TITLE
increase query limit per page from 5000 to 100000

### DIFF
--- a/src/views/Tasks/Export.js
+++ b/src/views/Tasks/Export.js
@@ -100,7 +100,7 @@ class Export extends Component {
     }
 
     async setTask(id) {
-        const t = await this.props.client.service('tasks').get(id, { query: { perPage: 5000 } });
+        const t = await this.props.client.service('tasks').get(id, { query: { perPage: 100000 } });
         console.log(t);
         this.setState({ myTask: t });
 


### PR DESCRIPTION
Increase query limit per page from 5000 to 100000 for now to allow all results to be dumped. Might need to come back and address timeout issue if it happens in the future. 